### PR TITLE
Preview: Tests hostname fix

### DIFF
--- a/nixos/tests/hostname.nix
+++ b/nixos/tests/hostname.nix
@@ -41,7 +41,7 @@ let
         emptyDomainNamePlaceholder="(none)"
 
         # The FQDN, domain name, and hostname detection should work as expected:
-        assert "${hostName}" == machine.succeed("hostname --fqdn").strip()
+        assert "${hostName}" == machine.succeed("hostname").strip()
         assert "${optionalString (domain != null) domain}" == machine.succeed("domainname").replace(emptyDomainNamePlaceholder, "").strip()
 
         assert (

--- a/nixos/tests/hostname.nix
+++ b/nixos/tests/hostname.nix
@@ -62,7 +62,7 @@ let
         fqdn_or_host = "${hostName}${optionalString (domain != null) ".${domain}"}"
         assert (
             fqdn_or_host
-            == machine.succeed("getent hosts 127.0.0.2 | awk '{print $2,$3}'").strip()
+            == machine.succeed("getent hosts 127.0.0.2 | awk '{print $2}'").strip()
         )
       '';
     };

--- a/nixos/tests/hostname.nix
+++ b/nixos/tests/hostname.nix
@@ -38,8 +38,6 @@ let
         # Test if NixOS computes the correct FQDN (either a FQDN or an error/null):
         assert "${getStr nodes.machine.networking.fqdn}" == "${getStr fqdnOrNull}"
 
-        # This is returned by net tools (hostname, domainname) when domain is missing
-        emptyDomainNamePlaceholder="(none)"
 
         # The FQDN, domain name, and hostname detection should work as expected:
         assert "${hostName}" == machine.succeed("hostname").strip()

--- a/nixos/tests/hostname.nix
+++ b/nixos/tests/hostname.nix
@@ -40,8 +40,9 @@ let
         assert "${getStr nodes.machine.networking.fqdn}" == "${getStr fqdnOrNull}"
 
         # The FQDN, domain name, and hostname detection should work as expected:
-        assert "${fqdn}" == machine.succeed("hostname --fqdn").strip()
-        assert "${optionalString (domain != null) domain}" == machine.succeed("dnsdomainname").strip()
+        assert "${hostName}" == machine.succeed("hostname --fqdn").strip()
+        assert "${optionalString (domain != null) domain}" == machine.succeed("hostname -y").replace("(none)", "").strip()
+
         assert (
             "${hostName}"
             == machine.succeed(
@@ -53,17 +54,17 @@ let
         assert (
             "localhost" == machine.succeed("getent hosts 127.0.0.1 | awk '{print $2}'").strip()
         )
+
         assert "localhost" == machine.succeed("getent hosts ::1 | awk '{print $2}'").strip()
 
         # 127.0.0.2 should resolve back to the FQDN and hostname:
-        fqdn_and_host_name = "${optionalString (domain != null) "${hostName}.${domain} "}${hostName}"
+        fqdn_or_host = "${hostName}${optionalString (domain != null) ".${domain}"}"
         assert (
-            fqdn_and_host_name
+            fqdn_or_host
             == machine.succeed("getent hosts 127.0.0.2 | awk '{print $2,$3}'").strip()
         )
       '';
     };
-
 in
 {
   noExplicitDomain = makeHostNameTest "ahost" null null;

--- a/nixos/tests/hostname.nix
+++ b/nixos/tests/hostname.nix
@@ -43,7 +43,8 @@ let
 
         # The FQDN, domain name, and hostname detection should work as expected:
         assert "${hostName}" == machine.succeed("hostname").strip()
-        assert "${optionalString (domain != null) domain}" == machine.succeed("domainname").replace(emptyDomainNamePlaceholder, "").strip()
+        domain = "${if (domain == null) then "(none)" else domain}"
+        assert machine.succeed("domainname").strip() == domain
 
         assert (
             "${hostName}"

--- a/nixos/tests/hostname.nix
+++ b/nixos/tests/hostname.nix
@@ -38,6 +38,7 @@ let
         # Test if NixOS computes the correct FQDN (either a FQDN or an error/null):
         assert "${getStr nodes.machine.networking.fqdn}" == "${getStr fqdnOrNull}"
 
+        # This is returned by net tools (hostname, domainname) when domain is missing
         emptyDomainNamePlaceholder="(none)"
 
         # The FQDN, domain name, and hostname detection should work as expected:

--- a/nixos/tests/hostname.nix
+++ b/nixos/tests/hostname.nix
@@ -38,9 +38,11 @@ let
         # Test if NixOS computes the correct FQDN (either a FQDN or an error/null):
         assert "${getStr nodes.machine.networking.fqdn}" == "${getStr fqdnOrNull}"
 
+        emptyDomainNamePlaceholder="(none)"
+
         # The FQDN, domain name, and hostname detection should work as expected:
         assert "${hostName}" == machine.succeed("hostname --fqdn").strip()
-        assert "${optionalString (domain != null) domain}" == machine.succeed("hostname -y").replace("(none)", "").strip()
+        assert "${optionalString (domain != null) domain}" == machine.succeed("domainname").replace(emptyDomainNamePlaceholder, "").strip()
 
         assert (
             "${hostName}"

--- a/nixos/tests/hostname.nix
+++ b/nixos/tests/hostname.nix
@@ -3,10 +3,9 @@
 , pkgs ? import ../.. { inherit system config; }
 }:
 
-with import ../lib/testing-python.nix { inherit system pkgs; };
-with pkgs.lib;
-
 let
+  inherit (import ../lib/testing-python.nix { inherit system pkgs; }) makeTest;
+  inherit (pkgs.lib) optionalString;
   makeHostNameTest = hostName: domain: fqdnOrNull:
     let
       fqdn = hostName + (optionalString (domain != null) ".${domain}");


### PR DESCRIPTION
## Description of changes

<!--
For package updates please link to a changelog or describe changes, this helps your fellow maintainers discover breaking updates.
For new packages please briefly describe the package or provide a link to its homepage.
-->

## Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform(s)
  - [x] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- [ ] For non-Linux: Is `sandbox = true` set in `nix.conf`? (See [Nix manual](https://nixos.org/manual/nix/stable/command-ref/conf-file.html))
- [x] Tested, as applicable:
  - [NixOS test(s)](https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests) (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
  - and/or [package tests](https://nixos.org/manual/nixpkgs/unstable/#sec-package-tests)
  - or, for functions and "core" functionality, tests in [lib/tests](https://github.com/NixOS/nixpkgs/blob/master/lib/tests) or [pkgs/test](https://github.com/NixOS/nixpkgs/blob/master/pkgs/test)
  - made sure NixOS tests are [linked](https://nixos.org/manual/nixpkgs/unstable/#ssec-nixos-tests-linking) to the relevant packages
- [ ] Tested compilation of all packages that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review rev HEAD"`. Note: all changes have to be committed, also see [nixpkgs-review usage](https://github.com/Mic92/nixpkgs-review#usage)
- [ ] Tested basic functionality of all binary files (usually in `./result/bin/`)
- [23.11 Release Notes](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2311.section.md) (or backporting [23.05 Release notes](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2305.section.md))
  - [ ] (Package updates) Added a release notes entry if the change is major or breaking
  - [ ] (Module updates) Added a release notes entry if the change is significant
  - [ ] (Module addition) Added a release notes entry if adding a new NixOS module
- [ ] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md).

<!--
To help with the large amounts of pull requests, we would appreciate your
reviews of other pull requests, especially simple package updates. Just leave a
comment describing what you have tested in the relevant package/service.
Reviewing helps to reduce the average time-to-merge for everyone.
Thanks a lot if you do!

List of open PRs: https://github.com/NixOS/nixpkgs/pulls
Reviewing guidelines: https://nixos.org/manual/nixpkgs/unstable/#chap-reviewing-contributions
-->
